### PR TITLE
Fix crashes

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -557,6 +557,8 @@ void Schematic::contentsMouseMoveEvent(QMouseEvent *Event)
       return condition ? misc::num2str(number) : misc::StringNiceNum(number);
     };
 
+    if (Diagrams == nullptr) return; // fix for crash on document closing; appears time to time
+
     for (Diagram* diagram = Diagrams->last(); diagram != nullptr; diagram = Diagrams->prev()) {
         // BUG: Obtaining the diagram type by name is marked as a bug elsewhere (to be solved separately).
         // TODO: Currently only rectangular diagrams are supported.

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -866,6 +866,8 @@ bool Schematic::loadPaintings(QTextStream *stream, Q3PtrList<Painting> *List)
   QString Line, cstr;
   while(!stream->atEnd()) {
     Line = stream->readLine();
+    if (Line.trimmed().isEmpty()) continue;
+
     if(Line.at(0) == '<') if(Line.at(1) == '/') return true;
 
     Line = Line.trimmed();


### PR DESCRIPTION
Fixes some crashes found on the latest `current` branch

* Fix crash on closing of the schematic tab. This crash appears time to time after the last schematic tab is closed
* Fix crash on empty line in `<Paintings>`  section in the schematic files 